### PR TITLE
Fixed failing cryptotests for OpenJDK 11+

### DIFF
--- a/cryptotest/tests/AlgorithmParametersTests.java
+++ b/cryptotest/tests/AlgorithmParametersTests.java
@@ -43,11 +43,7 @@ import cryptotest.utils.TestResult;
 import java.security.*;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.DSAParameterSpec;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.InvalidParameterSpecException;
-import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.*;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
@@ -77,6 +73,8 @@ public class AlgorithmParametersTests extends AlgorithmTest {
             //order important!
             if (service.getAlgorithm().contains("DSA")) {
                 params = new DSAParameterSpec(BigInteger.ONE, BigInteger.ONE, BigInteger.ONE);
+            } else if (service.getAlgorithm().contains("RSASSA")) {
+                params = new PSSParameterSpec(10);
             } else if (service.getAlgorithm().contains("PBES2")) {
                 //it looks like bug, PBES2 in its internal except name like PBES2WithHmacSHAxyzAES_abc
                 params = new PBEParameterSpec(new byte[]{1, 2, 3, 4}, 10);
@@ -106,6 +104,9 @@ public class AlgorithmParametersTests extends AlgorithmTest {
                 params = new OAEPParameterSpec("sha1", "MGF1", new MGF1ParameterSpec("sha1"), new PSource.PSpecified(new byte[]{1, 2, 3}));
             } else if (service.getAlgorithm().contains("EC")) {
                 params = new ECGenParameterSpec("1.2.840.10045.3.1.7");
+            } else if (service.getAlgorithm().contains("ChaCha20")){
+                // must be 12 bytes long
+                params = new IvParameterSpec(new byte[]{1,2,3,4,5,6,7,8,9,10,11,12});
             }
 
             c.init(params);

--- a/cryptotest/tests/CipherTests.java
+++ b/cryptotest/tests/CipherTests.java
@@ -41,11 +41,10 @@ import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
 import cryptotest.utils.TestResult;
 
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
+import javax.crypto.*;
+import javax.crypto.spec.IvParameterSpec;
 import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
@@ -116,6 +115,10 @@ public class CipherTests extends AlgorithmTest {
             } else if (service.getAlgorithm().contains("ARCFOUR")) {
                 b = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
                 key = getArcFourKey();
+            } else if (service.getAlgorithm().contains("ChaCha20")) {
+                AlgorithmParameterSpec params = new IvParameterSpec(new byte[]{1,2,3,4,5,6,7,8,9,10,11,12});
+                KeyGenerator.getInstance("ChaCha20").init(params);
+                key = KeyGenerator.getInstance("ChaCha20").generateKey();
             }
 
             if (service.getAlgorithm().toLowerCase().contains("wrap")) {
@@ -130,7 +133,7 @@ public class CipherTests extends AlgorithmTest {
                     }
                 }
             }
-        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeySpecException ex) {
+        } catch(NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException| InvalidKeySpecException ex){
             throw new AlgorithmInstantiationException(ex);
         } catch (IllegalBlockSizeException | BadPaddingException | InvalidKeyException |
                 UnsupportedOperationException | InvalidParameterException | ProviderException ex) {

--- a/cryptotest/tests/KeyAgreementTests.java
+++ b/cryptotest/tests/KeyAgreementTests.java
@@ -4,14 +4,12 @@ import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
 import cryptotest.utils.TestResult;
-import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
+
+import java.security.*;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.KeyAgreement;
 import com.sun.crypto.provider.DHKeyPairGenerator;
-import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import sun.security.ec.ECKeyPairGenerator;
 
 public class KeyAgreementTests extends AlgorithmTest {
@@ -32,7 +30,17 @@ public class KeyAgreementTests extends AlgorithmTest {
             if ("ECDH".equals(alias)) {
                 keypair = new ECKeyPairGenerator().generateKeyPair();
                 
-            } else {
+            } else if (service.getAlgorithm().startsWith("XDH")){
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
+                keypair = kpg.generateKeyPair();
+            } else if (service.getAlgorithm().startsWith("X25519")){
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519");
+                keypair = kpg.generateKeyPair();
+            } else if (service.getAlgorithm().contains("X448")) {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X448");
+                keypair = kpg.generateKeyPair();
+            }
+            else {
                 keypair = new DHKeyPairGenerator().generateKeyPair();
             }
             PrivateKey pk = keypair.getPrivate();

--- a/cryptotest/tests/KeyFactoryTests.java
+++ b/cryptotest/tests/KeyFactoryTests.java
@@ -9,22 +9,11 @@ import cryptotest.utils.TestResult;
 import javax.crypto.spec.DESKeySpec;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.DHPublicKeySpec;
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
+import java.security.*;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
-import java.security.spec.DSAPrivateKeySpec;
-import java.security.spec.DSAPublicKeySpec;
-import java.security.spec.ECPrivateKeySpec;
-import java.security.spec.ECPublicKeySpec;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
-import java.security.spec.RSAPrivateKeySpec;
-import java.security.spec.RSAPublicKeySpec;
+import java.security.interfaces.RSAMultiPrimePrivateCrtKey;
+import java.security.spec.*;
 
 import static java.math.BigInteger.ONE;
 
@@ -49,16 +38,38 @@ public class KeyFactoryTests extends AlgorithmTest {
                 KeyPair kp = KeysNaiveGenerator.getDsaKeyPair();
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), DSAPrivateKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), DSAPublicKeySpec.class);
+            }else if (service.getAlgorithm().contains("RSASSA-PSS")) {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+                KeyPair kp = kpg.generateKeyPair();
+                privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), RSAPrivateKeySpec.class);
+                publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), RSAPublicKeySpec.class);
+
+            } else if (service.getAlgorithm().contains("X25519")) {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519");
+                KeyPair kp = kpg.generateKeyPair();
+                privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class);
+                publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class);
+
+            } else if (service.getAlgorithm().contains("X448")) {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X448");
+                KeyPair kp = kpg.generateKeyPair();
+                privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class);
+                publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class);
+
+            } else if (service.getAlgorithm().contains("XDH")) {
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
+                KeyPair kp = kpg.generateKeyPair();
+                privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class);
+                publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class);
+
             } else if (service.getAlgorithm().contains("RSA")) {
                 KeyPair kp = KeysNaiveGenerator.getRsaKeyPair();
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), RSAPrivateKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), RSAPublicKeySpec.class);
             } else if (service.getAlgorithm().contains("EC")) {
                 KeyPair keyPair = KeyPairGenerator.getInstance("EC").genKeyPair();
-
                 ECPrivateKey ecPrivateKey = ((ECPrivateKey) keyPair.getPrivate());
                 ECPublicKey ecPublicKey = ((ECPublicKey) keyPair.getPublic());
-
                 privateKeySpec = new ECPrivateKeySpec(ONE, ecPrivateKey.getParams());
                 publicKeySpec = new ECPublicKeySpec(ecPublicKey.getW(), ecPublicKey.getParams());
             } else if (service.getAlgorithm().contains("DiffieHellman") || service.getAlgorithm().contains("DH")) {

--- a/cryptotest/tests/KeyPairGeneratorTests.java
+++ b/cryptotest/tests/KeyPairGeneratorTests.java
@@ -30,6 +30,12 @@ public class KeyPairGeneratorTests extends AlgorithmTest {
             int keySize = 512;
             if (service.getAlgorithm().contains("EC")) {
                 keySize = 256;
+            } else if (service.getAlgorithm().contains("XDH") || service.getAlgorithm().contains("X25519")){
+                // https://docs.oracle.com/en/java/javase/11/security/oracle-providers.html#GUID-B1F2B3F3-F2A4-4FF5-8887-3B3335343B2A
+                keySize = 255;
+            } else if (service.getAlgorithm().contains("X448")){
+                // https://docs.oracle.com/en/java/javase/11/security/oracle-providers.html#GUID-B1F2B3F3-F2A4-4FF5-8887-3B3335343B2A
+                keySize = 448;
             }
             keyPairGenerator.initialize(keySize, random);
             KeyPair pair = keyPairGenerator.genKeyPair();

--- a/cryptotest/tests/SignatureTests.java
+++ b/cryptotest/tests/SignatureTests.java
@@ -45,6 +45,7 @@ import static cryptotest.utils.KeysNaiveGenerator.getDsaPrivateKey1024;
 import cryptotest.utils.TestResult;
 
 import java.security.*;
+import java.security.spec.PSSParameterSpec;
 
 /*
  * IwishThisCouldBeAtTest
@@ -83,6 +84,11 @@ public class SignatureTests extends AlgorithmTest {
                 } else {
                     key = getDsaPrivateKey();
                 }
+            } else if (service.getAlgorithm().contains("RSASSA-PSS")){
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+                KeyPair kp = kpg.generateKeyPair();
+                key = kp.getPrivate();
+                sig.setParameter(new PSSParameterSpec(10));
             }
             sig.initSign(key);
             //NONEwithDSA needs 20bytes
@@ -93,7 +99,8 @@ public class SignatureTests extends AlgorithmTest {
             AlgorithmTest.printResult(res);
         } catch (NoSuchAlgorithmException ex) {
             throw new AlgorithmInstantiationException(ex);
-        } catch (InvalidKeyException | UnsupportedOperationException | InvalidParameterException | SignatureException | ProviderException ex) {
+        } catch (InvalidKeyException | UnsupportedOperationException | InvalidParameterException | SignatureException |
+                InvalidAlgorithmParameterException | ProviderException ex) {
             throw new AlgorithmRunException(ex);
         }
 


### PR DESCRIPTION
There are new curves, that need different parameters or specs, so it was fake failing.

Only three tests keep failing, I am still investigating why.