### PR TITLE
FIPS fixes: key generation, block size fixes

### DIFF
--- a/cryptotest/Settings.java
+++ b/cryptotest/Settings.java
@@ -54,8 +54,6 @@ public class Settings {
     public static boolean skipAgentTests = getBooleanProperty("cryptotests.skipAgentTests", false);
     //not only names of algorithms will be invoked, but also all aliases. Number of tests multiply by aprox 3, but right thing to do
     public static boolean testAliases = true;
-    // all mechanisms ar enot only initiated, but also used, nss have some issues right now
-    public static boolean runNss = true;
 
     public static class VerbositySettings {
 

--- a/cryptotest/tests/CertPathBuilderTests.java
+++ b/cryptotest/tests/CertPathBuilderTests.java
@@ -45,13 +45,13 @@ public class CertPathBuilderTests extends AlgorithmTest {
 
             KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
             ks.load(null, new char[]{104, 111, 118, 110, 111});
-            ks.setCertificateEntry("bbb", new DummyCertificate());
+            ks.setCertificateEntry("bbb", new DummyCertificate(service.getProvider()));
 
-            CertStore cs = CertStore.getInstance("Collection", new CollectionCertStoreParameters(Arrays.asList(new DummyCertificate(), new DummyCertificate())));
+            CertStore cs = CertStore.getInstance("Collection", new CollectionCertStoreParameters(Arrays.asList(new DummyCertificate(service.getProvider()), new DummyCertificate(service.getProvider()))));
 
 
             Set<TrustAnchor> trustAnchors = new HashSet<>();
-            trustAnchors.add(new TrustAnchor(new DummyCertificate(), null));
+            trustAnchors.add(new TrustAnchor(new DummyCertificate(service.getProvider()), null));
 
             PKIXBuilderParameters params = new PKIXBuilderParameters(ks, new X509CertSelector() {
                 @Override
@@ -72,9 +72,11 @@ public class CertPathBuilderTests extends AlgorithmTest {
 
     private static class DummyCertificate extends X509CertImpl {
 
-        private final KeyPair keyPair = KeysNaiveGenerator.getRsaKeyPair();
+        private final KeyPair keyPair;
 
-        private DummyCertificate() throws NoSuchAlgorithmException {}
+        private DummyCertificate(Provider provider) throws NoSuchAlgorithmException {
+            keyPair = KeysNaiveGenerator.getRsaKeyPair(provider);
+        }
 
         @Override
         public PublicKey getPublicKey() {

--- a/cryptotest/tests/KeyFactoryTests.java
+++ b/cryptotest/tests/KeyFactoryTests.java
@@ -35,39 +35,39 @@ public class KeyFactoryTests extends AlgorithmTest {
             KeySpec publicKeySpec;
 
             if (service.getAlgorithm().contains("DSA")) {
-                KeyPair kp = KeysNaiveGenerator.getDsaKeyPair();
+                KeyPair kp = KeysNaiveGenerator.getDsaKeyPair(service.getProvider());
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), DSAPrivateKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), DSAPublicKeySpec.class);
             }else if (service.getAlgorithm().contains("RSASSA-PSS")) {
-                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS", service.getProvider());
                 KeyPair kp = kpg.generateKeyPair();
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), RSAPrivateKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), RSAPublicKeySpec.class);
 
             } else if (service.getAlgorithm().contains("X25519")) {
-                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519");
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519", service.getProvider());
                 KeyPair kp = kpg.generateKeyPair();
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class);
 
             } else if (service.getAlgorithm().contains("X448")) {
-                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X448");
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("X448", service.getProvider());
                 KeyPair kp = kpg.generateKeyPair();
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class);
 
             } else if (service.getAlgorithm().contains("XDH")) {
-                KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH", service.getProvider());
                 KeyPair kp = kpg.generateKeyPair();
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class);
 
             } else if (service.getAlgorithm().contains("RSA")) {
-                KeyPair kp = KeysNaiveGenerator.getRsaKeyPair();
+                KeyPair kp = KeysNaiveGenerator.getRsaKeyPair(service.getProvider());
                 privateKeySpec = keyFactory.getKeySpec(kp.getPrivate(), RSAPrivateKeySpec.class);
                 publicKeySpec = keyFactory.getKeySpec(kp.getPublic(), RSAPublicKeySpec.class);
             } else if (service.getAlgorithm().contains("EC")) {
-                KeyPair keyPair = KeyPairGenerator.getInstance("EC").genKeyPair();
+                KeyPair keyPair = KeyPairGenerator.getInstance("EC", service.getProvider()).genKeyPair();
                 ECPrivateKey ecPrivateKey = ((ECPrivateKey) keyPair.getPrivate());
                 ECPublicKey ecPublicKey = ((ECPublicKey) keyPair.getPublic());
                 privateKeySpec = new ECPrivateKeySpec(ONE, ecPrivateKey.getParams());

--- a/cryptotest/tests/KeyInfoFactoryTests.java
+++ b/cryptotest/tests/KeyInfoFactoryTests.java
@@ -42,7 +42,7 @@ public class KeyInfoFactoryTests extends AlgorithmTest {
             RetrievalMethod retrievalMethod = keyInfoFactory.newRetrievalMethod("bbb");
             KeyValue keyValue = null;
             try {
-                keyValue = keyInfoFactory.newKeyValue(KeysNaiveGenerator.getRsaKeyPair().getPublic());
+                keyValue = keyInfoFactory.newKeyValue(KeysNaiveGenerator.getRsaKeyPair(service.getProvider()).getPublic());
             } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();
             }

--- a/cryptotest/tests/MacTests.java
+++ b/cryptotest/tests/MacTests.java
@@ -39,11 +39,11 @@ import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
 import cryptotest.utils.KeysNaiveGenerator;
-import static cryptotest.utils.KeysNaiveGenerator.getBlowfishKey;
 import cryptotest.utils.TestResult;
 
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
+import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.spec.PBEParameterSpec;
 
@@ -75,7 +75,15 @@ public class MacTests extends AlgorithmTest {
                 PBEParameterSpec parmas = new PBEParameterSpec(new byte[]{1, 2, 3, 4, 5, 6, 7, 8}, 5);
                 md.init(key, parmas);
             } else {
-                Key key = getBlowfishKey();
+                KeyGenerator kg;
+                try {
+                    kg = KeysNaiveGenerator.getKeyGenerator(service.getAlgorithm(), service.getProvider());
+                } catch (NoSuchAlgorithmException e) {
+                    // No KeyGenerator, which could generate compatible keys found
+                    // so just return here
+                    return;
+                }
+                Key key = kg.generateKey();
                 md.init(key);
             }
 

--- a/cryptotest/tests/SignatureTests.java
+++ b/cryptotest/tests/SignatureTests.java
@@ -67,11 +67,11 @@ public class SignatureTests extends AlgorithmTest {
         try {
             Signature sig = Signature.getInstance(alias, service.getProvider());
             //most of them are happy with rsa...
-            PrivateKey key = getRsaPrivateKey();
+            PrivateKey key = getRsaPrivateKey(service.getProvider());
             if (service.getAlgorithm().contains("EC")) {
-                key = getEcPrivateKey();
+                key = getEcPrivateKey(service.getProvider());
             } else if (service.getAlgorithm().contains("DSA")) {
-                if (service.getAlgorithm().contains("SHA1")) {
+                //if (service.getAlgorithm().contains("SHA1")) {
                     /* SHA1 is not sufficient for default DSA key size,
                        throwing:
                        java.security.InvalidKeyException: The security strength of SHA-1 digest algorithm is not sufficient for this key size
@@ -79,13 +79,17 @@ public class SignatureTests extends AlgorithmTest {
                        See:
                        https://bugs.java.com/view_bug.do?bug_id=8184341
                        http://hg.openjdk.java.net/jdk8u/jdk8u-dev/jdk/file/8a97a690a0b3/src/share/classes/sun/security/provider/DSA.java#l104
+
+                       1024-bits is also needed for pkcs11 in fips mode, default size does not work there
                     */
-                    key = getDsaPrivateKey1024();
+                    key = getDsaPrivateKey1024(service.getProvider());
+                    /*
                 } else {
-                    key = getDsaPrivateKey();
+                    key = getDsaPrivateKey(service.getProvider());
                 }
+                */
             } else if (service.getAlgorithm().contains("RSASSA-PSS")){
-                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+                KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS", service.getProvider());
                 KeyPair kp = kpg.generateKeyPair();
                 key = kp.getPrivate();
                 sig.setParameter(new PSSParameterSpec(10));

--- a/cryptotest/utils/KeysNaiveGenerator.java
+++ b/cryptotest/utils/KeysNaiveGenerator.java
@@ -42,6 +42,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.spec.InvalidKeySpecException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -52,8 +53,30 @@ import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
 
 public class KeysNaiveGenerator {
 
-    public static Key getDesKey() throws NoSuchAlgorithmException {
-        KeyGenerator keyGenerator = KeyGenerator.getInstance("DES");
+    public static KeyGenerator getKeyGenerator(String name, Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator kg;
+        try {
+            kg = KeyGenerator.getInstance(name, provider);
+        } catch (NoSuchAlgorithmException e) {
+            kg = KeyGenerator.getInstance(name);
+        }
+        return kg;
+    }
+
+    public static KeyPairGenerator getKeyPairGenerator(String name, Provider provider) throws NoSuchAlgorithmException {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance(name, provider);
+        } catch (NoSuchAlgorithmException e) {
+            kpg = KeyPairGenerator.getInstance(name);
+        }
+        return kpg;
+    }
+
+
+
+    public static Key getDesKey(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator keyGenerator = getKeyGenerator("DES", provider);
         keyGenerator.init(56);
         return keyGenerator.generateKey();
     }
@@ -110,55 +133,54 @@ public class KeysNaiveGenerator {
         return key;
     }
 
-    public static SecretKey getDesedeKey() throws NoSuchAlgorithmException {
-        KeyGenerator keyGenerator = KeyGenerator.getInstance("DESede");
-        keyGenerator.init(112);
+    public static SecretKey getDesedeKey(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator keyGenerator = getKeyGenerator("DESede", provider);
+        /* keyGenerator.init(112); */
         return keyGenerator.generateKey();
     }
 
-    public static KeyPair getRsaKeyPair() throws NoSuchAlgorithmException {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+    public static KeyPair getRsaKeyPair(Provider provider) throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = getKeyPairGenerator("RSA", provider);
         return keyGen.genKeyPair();
     }
 
-    public static PrivateKey getRsaPrivateKey() throws NoSuchAlgorithmException {
-        return getRsaKeyPair().getPrivate();
+    public static PrivateKey getRsaPrivateKey(Provider provider) throws NoSuchAlgorithmException {
+        return getRsaKeyPair(provider).getPrivate();
 
     }
 
-    public static KeyPair getDsaKeyPair() throws NoSuchAlgorithmException {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DSA");
+    public static KeyPair getDsaKeyPair(Provider provider) throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = getKeyPairGenerator("DSA", provider);
         return keyGen.genKeyPair();
     }
 
-    public static PrivateKey getDsaPrivateKey() throws NoSuchAlgorithmException {
-        return getDsaKeyPair().getPrivate();
+    public static PrivateKey getDsaPrivateKey(Provider provider) throws NoSuchAlgorithmException {
+        return getDsaKeyPair(provider).getPrivate();
     }
 
-    public static KeyPair getDsaKeyPair1024() throws NoSuchAlgorithmException {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DSA");
+    public static KeyPair getDsaKeyPair1024(Provider provider) throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = getKeyPairGenerator("DSA", provider);
         keyGen.initialize(1024);
         return keyGen.genKeyPair();
     }
 
-    public static PrivateKey getDsaPrivateKey1024() throws NoSuchAlgorithmException {
-        return getDsaKeyPair1024().getPrivate();
+    public static PrivateKey getDsaPrivateKey1024(Provider provider) throws NoSuchAlgorithmException {
+        return getDsaKeyPair1024(provider).getPrivate();
     }
 
-    public static KeyPair getEcKeyPair() throws NoSuchAlgorithmException {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+    public static KeyPair getEcKeyPair(Provider provider) throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = getKeyPairGenerator("EC", provider);
         return keyGen.genKeyPair();
     }
 
-    public static PrivateKey getEcPrivateKey() throws NoSuchAlgorithmException {
-        return getEcKeyPair().getPrivate();
+    public static PrivateKey getEcPrivateKey(Provider provider) throws NoSuchAlgorithmException {
+        return getEcKeyPair(provider).getPrivate();
 
     }
 
-    public static SecretKey getBlowfishKey() {
-        String Key = "Something";
-        byte[] KeyData = Key.getBytes();
-        return new SecretKeySpec(KeyData, "Blowfish");
+    public static SecretKey getBlowfishKey(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator kg = getKeyGenerator("Blowfish", provider);
+        return kg.generateKey();
     }
 
     public static SecretKey getRc2Key() {
@@ -167,28 +189,26 @@ public class KeysNaiveGenerator {
         return new SecretKeySpec(KeyData, "RC2");
     }
 
-    public static SecretKey getArcFourKey() {
-        String Key = "Something";
-        byte[] KeyData = Key.getBytes();
-        return new SecretKeySpec(KeyData, "ARCFOUR");
+    public static SecretKey getArcFourKey(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator kg = getKeyGenerator("ARCFOUR", provider);
+        return kg.generateKey();
     }
 
-    public static SecretKey getAesKey() {
-//sorry, aligned with length of message
-        String key = "exactlyEg16bytes";
-        byte[] KeyData = key.getBytes();
-        return new SecretKeySpec(KeyData, "AES");
+    public static SecretKey getAesKey(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator kg = getKeyGenerator("AES", provider);
+        kg.init(128);
+        return kg.generateKey();
     }
 
-    public static SecretKey getAesKey192() {
-        String key192 = "24charsToCreate192bitess";
-        byte[] KeyData = key192.getBytes();
-        return new SecretKeySpec(KeyData, "AES");
+    public static SecretKey getAesKey192(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator kg = getKeyGenerator("AES", provider);
+        kg.init(192);
+        return kg.generateKey();
     }
 
-    public static SecretKey getAesKey256() {
-        String key192 = "32charsToCreate26bitesssssssssss";
-        byte[] KeyData = key192.getBytes();
-        return new SecretKeySpec(KeyData, "AES");
+    public static SecretKey getAesKey256(Provider provider) throws NoSuchAlgorithmException {
+        KeyGenerator kg = getKeyGenerator("AES", provider);
+        kg.init(256);
+        return kg.generateKey();
     }
 }


### PR DESCRIPTION
This PR does some fixes for FIPS mode:
- we can not use "RAW" keys (so generators are used)
- fixed block size detection in CipherTests

Testsuites fixed: SignatureTests, CipherTests, CertPathBuilderTests, MacTests

more to be done...
